### PR TITLE
feat: add autoware_internal_debug_msgs package

### DIFF
--- a/autoware_internal_debug_msgs/CMakeLists.txt
+++ b/autoware_internal_debug_msgs/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_internal_debug_msgs)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+set(msg_files
+  "msg/StringStamped.msg"
+)
+
+set(msg_dependencies
+  builtin_interfaces
+  std_msgs
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES ${msg_dependencies}
+  ADD_LINTER_TESTS
+)
+
+ament_auto_package()

--- a/autoware_internal_debug_msgs/msg/StringStamped.msg
+++ b/autoware_internal_debug_msgs/msg/StringStamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+string data

--- a/autoware_internal_debug_msgs/package.xml
+++ b/autoware_internal_debug_msgs/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_internal_debug_msgs</name>
+  <version>1.1.0</version>
+  <description>Autoware internal debug messages package.</description>
+  <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
+  <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
+  <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>


### PR DESCRIPTION
## Description

Based on the following issues, I created `autoware_internal_debug_msgs` package and move the `StringStamped` message from `tier4_debug_msgs` package.
https://github.com/autowarefoundation/autoware/issues/5580
<!-- Write a brief description of this PR. -->

## Tests performed

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
