### PR TITLE
feat(autoware_internal_debug_msgs): add ProcessingTime msgs

### DIFF
--- a/autoware_internal_debug_msgs/CMakeLists.txt
+++ b/autoware_internal_debug_msgs/CMakeLists.txt
@@ -15,6 +15,8 @@ set(msg_files
   "msg/Int64Stamped.msg"
   "msg/Int64MultiArrayStamped.msg"
   "msg/StringStamped.msg"
+  "msg/ProcessingTimeNode.msg"
+  "msg/ProcessingTimeTree.msg"
 )
 
 set(srv_files

--- a/autoware_internal_debug_msgs/msg/ProcessingTimeNode.msg
+++ b/autoware_internal_debug_msgs/msg/ProcessingTimeNode.msg
@@ -1,0 +1,10 @@
+# Unique ID of the node
+int32 id
+# Name of the node
+string name
+# Processing time of the node
+float64 processing_time
+# ID of the parent node, 0 if no parent
+int32 parent_id
+# Comment
+string comment

--- a/autoware_internal_debug_msgs/msg/ProcessingTimeTree.msg
+++ b/autoware_internal_debug_msgs/msg/ProcessingTimeTree.msg
@@ -1,0 +1,2 @@
+# Array of all time nodes
+ProcessingTimeNode[] nodes


### PR DESCRIPTION
## Description

[This porting guideline](https://docs.google.com/document/d/1kKshojZo8RuYQ-WhIqQCqTKQO3ojTb5RB77V3NjYpdU/edit?tab=t.0#heading=h.185kwwpluhpx) requires that each package can only use messages defined under AutowareFoundation GitHub Org, and I have noticed that
**(ProcessingTimeNode.msg, ProcessingTimeTree.msg)** missed when moving to autoware_internal_debug_msgs, and these two messages are still being used in [Autoware.Universe](https://github.com/autowarefoundation/autoware.universe/blob/ffbddad7cb3274ab9bb430477413370f08b26c3e/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp#L22).

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
