### PR TITLE
feat(autoware_internal_planning_msgs): add PathWithLaneId.msg

### DIFF
--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.5)
+project(autoware_internal_planning_msgs)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/PathPoint.msg"
+  "msg/PathPointWithLaneId.msg"
+  "msg/PathWithLaneId.msg"
+  DEPENDENCIES
+    builtin_interfaces
+    geometry_msgs
+    std_msgs
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package()

--- a/autoware_internal_planning_msgs/msg/PathPoint.msg
+++ b/autoware_internal_planning_msgs/msg/PathPoint.msg
@@ -1,0 +1,5 @@
+geometry_msgs/Pose pose
+float32 longitudinal_velocity_mps
+float32 lateral_velocity_mps
+float32 heading_rate_rps
+bool is_final

--- a/autoware_internal_planning_msgs/msg/PathPointWithLaneId.msg
+++ b/autoware_internal_planning_msgs/msg/PathPointWithLaneId.msg
@@ -1,0 +1,2 @@
+autoware_internal_planning_msgs/PathPoint point
+int64[] lane_ids

--- a/autoware_internal_planning_msgs/msg/PathWithLaneId.msg
+++ b/autoware_internal_planning_msgs/msg/PathWithLaneId.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+autoware_internal_planning_msgs/PathPointWithLaneId[] points
+geometry_msgs/Point[] left_bound
+geometry_msgs/Point[] right_bound

--- a/autoware_internal_planning_msgs/package.xml
+++ b/autoware_internal_planning_msgs/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_internal_planning_msgs</name>
+  <version>0.1.0</version>
+  <description>The autoware_internal_planning_msgs package</description>
+  <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
+  <maintainer email="cynthia.liu@autocore.ai">Cynthia Liu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/autoware_internal_planning_msgs/package.xml
+++ b/autoware_internal_planning_msgs/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
-  
+
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>builtin_interfaces</depend>


### PR DESCRIPTION
## Description

I was planning to migrate `autoware_universe_utils` from autoware.universe to auoware.core, but this package used `tier4_planning_msgs`, So, before migrating, I need to add `tier4_planning_msg`  used in `autoware_universe_utils` to `autoware_internal_msgs` repos.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
