### PR TITLE
fix(autoware_internal_planning_msgs): fix PathPoint type error cause by duplicate definition in repo autoware_msgs and autoware_internal_msgs

### DIFF
--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/PathPoint.msg"
   "msg/PathPointWithLaneId.msg"
   "msg/PathWithLaneId.msg"
   "msg/Scenario.msg"
@@ -23,6 +22,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     builtin_interfaces
     geometry_msgs
     std_msgs
+    autoware_planning_msgs
 )
 
 if(BUILD_TESTING)

--- a/autoware_internal_planning_msgs/msg/PathPoint.msg
+++ b/autoware_internal_planning_msgs/msg/PathPoint.msg
@@ -1,5 +1,0 @@
-geometry_msgs/Pose pose
-float32 longitudinal_velocity_mps
-float32 lateral_velocity_mps
-float32 heading_rate_rps
-bool is_final

--- a/autoware_internal_planning_msgs/msg/PathPointWithLaneId.msg
+++ b/autoware_internal_planning_msgs/msg/PathPointWithLaneId.msg
@@ -1,2 +1,2 @@
-autoware_internal_planning_msgs/PathPoint point
+autoware_planning_msgs/PathPoint point
 int64[] lane_ids

--- a/autoware_internal_planning_msgs/package.xml
+++ b/autoware_internal_planning_msgs/package.xml
@@ -16,6 +16,7 @@
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/autoware_internal_planning_msgs/package.xml
+++ b/autoware_internal_planning_msgs/package.xml
@@ -13,10 +13,10 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>autoware_planning_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>autoware_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Description

Fix PathPoint type error cause by duplicate definition in repo autoware_msgs and autoware_internal_msgs ([error source](https://github.com/NorahXiong/autoware.core/blob/porting/autoware_motion_utils/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/conversion.hpp#L59-L72))

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
