### PR TITLE
feat: port VelocityLimit messages from tier4_planning_msgs

### DIFF
--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -23,6 +23,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/SafetyFactorArray.msg"
   "msg/PlanningFactor.msg"
   "msg/PlanningFactorArray.msg"
+  "msg/VelocityLimit.msg"
+  "msg/VelocityLimitConstraints.msg"
+  "msg/VelocityLimitClearCommand.msg"
   DEPENDENCIES
     builtin_interfaces
     geometry_msgs

--- a/autoware_internal_planning_msgs/msg/VelocityLimit.msg
+++ b/autoware_internal_planning_msgs/msg/VelocityLimit.msg
@@ -1,0 +1,7 @@
+builtin_interfaces/Time stamp
+float32 max_velocity
+
+bool use_constraints false
+autoware_internal_planning_msgs/VelocityLimitConstraints constraints
+
+string sender

--- a/autoware_internal_planning_msgs/msg/VelocityLimitClearCommand.msg
+++ b/autoware_internal_planning_msgs/msg/VelocityLimitClearCommand.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+bool command false
+string sender

--- a/autoware_internal_planning_msgs/msg/VelocityLimitConstraints.msg
+++ b/autoware_internal_planning_msgs/msg/VelocityLimitConstraints.msg
@@ -1,0 +1,11 @@
+# maximum signed acceleration
+float32 max_acceleration
+
+# minimum signed acceleration
+float32 min_acceleration
+
+# maximum signed jerk
+float32 max_jerk
+
+# minimum signed jerk
+float32 min_jerk


### PR DESCRIPTION
## Description
This adds VelocityLimit message to autoware_internal_planning_msgs package.

We would like to remove dependency on tier4_planning_msgs to port autoware_velocity_smoother into Autoware Core as part of https://github.com/autowarefoundation/autoware.core/issues/192.

## How was this PR tested?

This will be tested with build CI.

## Notes for reviewers

None.

## Effects on system behavior

None.
