### PR TITLE
feat(autoware_internal_planning_msgs): port routing services from tier4_planning_msgs

### DIFF
--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -23,14 +23,19 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/SafetyFactorArray.msg"
   "msg/PlanningFactor.msg"
   "msg/PlanningFactorArray.msg"
+  "msg/RouteState.msg"
   "msg/VelocityLimit.msg"
   "msg/VelocityLimitConstraints.msg"
   "msg/VelocityLimitClearCommand.msg"
+  "srv/ClearRoute.srv"
+  "srv/SetLaneletRoute.srv"
+  "srv/SetWaypointRoute.srv"
   DEPENDENCIES
     builtin_interfaces
     geometry_msgs
     std_msgs
     unique_identifier_msgs
+    autoware_common_msgs
     autoware_perception_msgs
     autoware_planning_msgs
 )

--- a/autoware_internal_planning_msgs/msg/RouteState.msg
+++ b/autoware_internal_planning_msgs/msg/RouteState.msg
@@ -1,0 +1,12 @@
+uint8 UNKNOWN = 0
+uint8 INITIALIZING = 1
+uint8 UNSET = 2
+uint8 ROUTING = 3
+uint8 SET = 4
+uint8 REROUTING = 5
+uint8 ARRIVED = 6
+uint8 ABORTED = 7
+uint8 INTERRUPTED = 8
+
+builtin_interfaces/Time stamp
+uint8 state

--- a/autoware_internal_planning_msgs/package.xml
+++ b/autoware_internal_planning_msgs/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>autoware_common_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>builtin_interfaces</depend>

--- a/autoware_internal_planning_msgs/srv/ClearRoute.srv
+++ b/autoware_internal_planning_msgs/srv/ClearRoute.srv
@@ -1,0 +1,2 @@
+---
+autoware_common_msgs/ResponseStatus status

--- a/autoware_internal_planning_msgs/srv/SetLaneletRoute.srv
+++ b/autoware_internal_planning_msgs/srv/SetLaneletRoute.srv
@@ -1,0 +1,7 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+autoware_planning_msgs/LaneletSegment[] segments
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+autoware_common_msgs/ResponseStatus status

--- a/autoware_internal_planning_msgs/srv/SetWaypointRoute.srv
+++ b/autoware_internal_planning_msgs/srv/SetWaypointRoute.srv
@@ -1,0 +1,7 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+geometry_msgs/Pose[] waypoints
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Description
This PR adds the following msg/service to autoware_internal_planning_msgs which are used for requesting global route planning:
- SetWaypointRoute.srv
- SetLaneletRoute.srv
- ClearRoute.srv
- RouteState.msg

The messages are required to port autoware_mission_planner from Autoware Universe to Core as part of [porting](https://github.com/orgs/autowarefoundation/discussions/5365). 

Related links:
- https://github.com/autowarefoundation/autoware_core/issues/265
- https://github.com/orgs/autowarefoundation/discussions/5365
- https://github.com/autowarefoundation/autoware_core/pull/329

## How was this PR tested?
This was tested with this PR in Autoware Core: https://github.com/autowarefoundation/autoware_core/pull/329

## Notes for reviewers

None.

## Effects on system behavior

None.
