### PR TITLE
feat(autoware_internal_msgs): make `autoware_internal_msgs` metapackage

### DIFF
--- a/autoware_internal_msgs/package.xml
+++ b/autoware_internal_msgs/package.xml
@@ -14,11 +14,11 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>autoware_internal_planning_msgs</exec_depend>
-  <exec_depend>autoware_internal_perception_msgs</exec_depend>
-  <exec_depend>autoware_internal_metric_msgs</exec_depend>
   <exec_depend>autoware_internal_debug_msgs</exec_depend>
+  <exec_depend>autoware_internal_metric_msgs</exec_depend>
+  <exec_depend>autoware_internal_perception_msgs</exec_depend>
+  <exec_depend>autoware_internal_planning_msgs</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <depend>builtin_interfaces</depend>
   <depend>std_msgs</depend>
 

--- a/autoware_internal_msgs/package.xml
+++ b/autoware_internal_msgs/package.xml
@@ -15,6 +15,10 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>autoware_internal_planning_msgs</exec_depend>
+  <exec_depend>autoware_internal_perception_msgs</exec_depend>
+  <exec_depend>autoware_internal_metric_msgs</exec_depend>
+  <exec_depend>autoware_internal_debug_msgs</exec_depend>
   <depend>builtin_interfaces</depend>
   <depend>std_msgs</depend>
 

--- a/autoware_internal_msgs/package.xml
+++ b/autoware_internal_msgs/package.xml
@@ -5,7 +5,7 @@
   <version>1.8.0</version>
   <description>Autoware internal messages package.</description>
   <maintainer email="berkay@leodrive.ai">Berkay Karaman</maintainer>
-  <maintainer email="mfc@leodrive.ai">M. Fatih Cırıt</maintainer>
+  <maintainer email="mfc@autoware.org">M. Fatih Cırıt</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>


### PR DESCRIPTION
## Description

This PR adds `exec_depend` to make the `autoware_internal_msgs` package behave like a metapackage for other packages.

Ref.

- https://github.com/autowarefoundation/autoware_msgs/pull/123

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
