### PR TITLE
feat(autoware_internal_planning_msgs): add new message definitions for new planning framework

### DIFF
--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -15,6 +15,11 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/CandidateTrajectories.msg"
+  "msg/CandidateTrajectory.msg"
+  "msg/GeneratorInfo.msg"
+  "msg/ScoredCandidateTrajectories.msg"
+  "msg/ScoredCandidateTrajectory.msg"
   "msg/PathPointWithLaneId.msg"
   "msg/PathWithLaneId.msg"
   "msg/Scenario.msg"

--- a/autoware_internal_planning_msgs/msg/CandidateTrajectories.msg
+++ b/autoware_internal_planning_msgs/msg/CandidateTrajectories.msg
@@ -1,0 +1,2 @@
+autoware_internal_planning_msgs/CandidateTrajectory[] candidate_trajectories
+autoware_internal_planning_msgs/TrajectoryGeneratorInfo[] generator_info

--- a/autoware_internal_planning_msgs/msg/CandidateTrajectories.msg
+++ b/autoware_internal_planning_msgs/msg/CandidateTrajectories.msg
@@ -1,2 +1,2 @@
 autoware_internal_planning_msgs/CandidateTrajectory[] candidate_trajectories
-autoware_internal_planning_msgs/TrajectoryGeneratorInfo[] generator_info
+autoware_internal_planning_msgs/GeneratorInfo[] generator_info

--- a/autoware_internal_planning_msgs/msg/CandidateTrajectory.msg
+++ b/autoware_internal_planning_msgs/msg/CandidateTrajectory.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+unique_identifier_msgs/UUID generator_id
+autoware_planning_msgs/TrajectoryPoint[] points

--- a/autoware_internal_planning_msgs/msg/GeneratorInfo.msg
+++ b/autoware_internal_planning_msgs/msg/GeneratorInfo.msg
@@ -1,0 +1,2 @@
+unique_identifier_msgs/UUID generator_id
+std_msgs/String generator_name

--- a/autoware_internal_planning_msgs/msg/ScoredCandidateTrajectories.msg
+++ b/autoware_internal_planning_msgs/msg/ScoredCandidateTrajectories.msg
@@ -1,0 +1,2 @@
+autoware_internal_planning_msgs/ScoredCandidateTrajectory[] scored_candidate_trajectories
+autoware_internal_planning_msgs/GeneratorInfo[] generator_info

--- a/autoware_internal_planning_msgs/msg/ScoredCandidateTrajectory.msg
+++ b/autoware_internal_planning_msgs/msg/ScoredCandidateTrajectory.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+unique_identifier_msgs/UUID generator_id
+autoware_planning_msgs/TrajectoryPoint[] points
+float32 score # Score should be in [0.0, 1.0]

--- a/autoware_internal_planning_msgs/msg/ScoredCandidateTrajectory.msg
+++ b/autoware_internal_planning_msgs/msg/ScoredCandidateTrajectory.msg
@@ -1,4 +1,2 @@
-std_msgs/Header header
-unique_identifier_msgs/UUID generator_id
-autoware_planning_msgs/TrajectoryPoint[] points
+autoware_internal_planning_msgs/CandidateTrajectory candidate_trajectory
 float32 score # Score should be in [0.0, 1.0]


### PR DESCRIPTION
## Description

**Parent Issue:**
- https://github.com/autowarefoundation/autoware/issues/6292

### Background

The current Autoware stack has grown for roughly four years on top of the original Autoware Architecture Proposal. Its hierarchical planning + modular components served well at first, but they now leave information gaps and limit flexibility. As we target dense urban scenarios—e.g., taxi deployments—the existing structure is reaching its limits.

### Issues

Behavior planning vs. motion planning split: In challenging scenes the two layers can disagree, so tight cross-module coordination is mandatory.

Adding scene-specific modules looks easy, yet each new component increases dependencies, code complexity, bug count, and long-term maintenance cost.

### Proposal — Generator-Selector Framework
Make Generators (trajectory-candidate producers) and a Selector (safety check + best-trajectory pick) the core loop.

Treat rule-based, optimization-based, and machine-learning approaches (E2E, diffusion models, etc.) as parallel Generator plugins.

In the Selector, perform a two-stage evaluation—Safety Gate ➜ Ranking—to combine hard safety guarantees for black-box models with scenario-dependent cost weighting.

Allow AV 1.0 (traditional stack) and AV 2.0 (data-driven stack) to coexist under one roof, so integrators can mix and match technology per operational design domain.

![image](https://github.com/user-attachments/assets/bbc96550-f697-43ba-be18-546eb4da065e)

## Discussion & Docs

Background: https://github.com/orgs/autowarefoundation/discussions/5032

Issues: https://github.com/orgs/autowarefoundation/discussions/5033

Proposal: https://github.com/tier4/new_planning_framework/wiki

TODO: https://github.com/tier4/new_planning_framework/wiki#modular-e2e--2-models-e2e

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
