### PR TITLE
feat(waypoint_maker): add WaypointFollowing scenario type to Scenario.msg

### DIFF
--- a/autoware_internal_planning_msgs/msg/Scenario.msg
+++ b/autoware_internal_planning_msgs/msg/Scenario.msg
@@ -1,6 +1,7 @@
 string EMPTY=Empty
 string LANEDRIVING=LaneDriving
 string PARKING=Parking
+string WAYPOINTFOLLOWING=WaypointFollowing
 
 string current_scenario
 string[] activating_scenarios


### PR DESCRIPTION
## Description
This PR adds a new scenario type `WAYPOINTFOLLOWING=WaypointFollowing` to `autoware_internal_planning_msgs/msg/Scenario.msg`.  
This allows the planning stack to represent and switch to the **Waypoint Following** scenario alongside existing LaneDriving and Parking scenarios.

## How was this PR tested?
Same to this [PR](https://github.com/autowarefoundation/autoware_universe/pull/11292)

## Notes for reviewers

None.

## Effects on system behavior

None.
