### PR TITLE
docs: add unit and range documentation to message fields

### DIFF
--- a/autoware_internal_planning_msgs/msg/ControlPoint.msg
+++ b/autoware_internal_planning_msgs/msg/ControlPoint.msg
@@ -1,4 +1,8 @@
+# Pose of the control point in map frame
 geometry_msgs/Pose pose
+# Velocity at control point [m/s]
 float32 velocity
+# Lateral shift length [m]. Positive: left, Negative: right
 float32 shift_length
+# Distance from ego vehicle [m]
 float32 distance

--- a/autoware_internal_planning_msgs/msg/SafetyFactor.msg
+++ b/autoware_internal_planning_msgs/msg/SafetyFactor.msg
@@ -14,9 +14,9 @@ unique_identifier_msgs/UUID object_id
 # use only for predicted objects
 autoware_perception_msgs/PredictedPath predicted_path
 
-# time to collision in relative to the header time
+# Time to collision (start) relative to the header time [s]
 float32 ttc_begin
-
+# Time to collision (end) relative to the header time [s]
 float32 ttc_end
 
 # type == POINTCLOUD: the position of the each points

--- a/autoware_internal_planning_msgs/msg/VelocityLimit.msg
+++ b/autoware_internal_planning_msgs/msg/VelocityLimit.msg
@@ -1,7 +1,20 @@
+# constants for sender
+string SENDER_API = "api"
+string SENDER_COMFORTABLE_STOP_SWITCHER = "comfortable_stop_switcher"
+string SENDER_MRM_COMFORTABLE_STOP_OPERATOR = "mrm_comfortable_stop_operator"
+string SENDER_OBSTACLE_CRUISE = "obstacle_cruise"
+string SENDER_OBSTACLE_SLOW_DOWN = "obstacle_slow_down"
+string SENDER_SURROUND_OBSTACLE_CHECKER = "surround_obstacle_checker"
+
+# fields
 builtin_interfaces/Time stamp
+# Maximum velocity [m/s]. Range: >= 0.0
 float32 max_velocity
 
+# Whether to use constraints
 bool use_constraints false
+# Velocity limit constraints (only used if use_constraints is true)
 autoware_internal_planning_msgs/VelocityLimitConstraints constraints
 
+# Identifier of the module that set this limit (use SENDER_* constants above)
 string sender

--- a/autoware_internal_planning_msgs/msg/VelocityLimit.msg
+++ b/autoware_internal_planning_msgs/msg/VelocityLimit.msg
@@ -1,10 +1,5 @@
-# constants for sender
+# constants for system-defined sender
 string SENDER_API = "api"
-string SENDER_COMFORTABLE_STOP_SWITCHER = "comfortable_stop_switcher"
-string SENDER_MRM_COMFORTABLE_STOP_OPERATOR = "mrm_comfortable_stop_operator"
-string SENDER_OBSTACLE_CRUISE = "obstacle_cruise"
-string SENDER_OBSTACLE_SLOW_DOWN = "obstacle_slow_down"
-string SENDER_SURROUND_OBSTACLE_CHECKER = "surround_obstacle_checker"
 
 # fields
 builtin_interfaces/Time stamp
@@ -16,5 +11,5 @@ bool use_constraints false
 # Velocity limit constraints (only used if use_constraints is true)
 autoware_internal_planning_msgs/VelocityLimitConstraints constraints
 
-# Identifier of the module that set this limit (use SENDER_* constants above)
+# Identifier of the module that set this limit (use SENDER_* constants above or any user-defined sender)
 string sender

--- a/autoware_internal_planning_msgs/msg/VelocityLimitClearCommand.msg
+++ b/autoware_internal_planning_msgs/msg/VelocityLimitClearCommand.msg
@@ -1,3 +1,5 @@
 builtin_interfaces/Time stamp
+# Whether to clear the velocity limit
 bool command false
+# Identifier of the module that clears the limit (see VelocityLimit.msg for SENDER_* constants)
 string sender


### PR DESCRIPTION
## Description

Add inline documentation comments to clarify units and valid ranges for message fields in autoware_internal_planning_msgs:

- `VelocityLimit.msg`: Added max_velocity unit [m/s] and range (>= 0.0), added string constants for sender field
- `VelocityLimitClearCommand.msg`: Added sender field description referencing VelocityLimit.msg constants
- `ControlPoint.msg`: Added units - velocity [m/s], shift_length [m], distance [m]
- `SafetyFactor.msg`: Added ttc_begin/ttc_end units [s]

Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106

## How was this PR tested?

Documentation-only changes. No functional changes to test.

## Notes for reviewers

None.

## Effects on system behavior

None. Only inline comment additions.