### PR TITLE
chore: make meta-package dependencies to depend from exec_depend

### DIFF
--- a/autoware_internal_msgs/package.xml
+++ b/autoware_internal_msgs/package.xml
@@ -14,12 +14,13 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_metric_msgs</depend>
   <depend>autoware_internal_perception_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>builtin_interfaces</depend>
-  <depend>rosidl_default_runtime</depend>
   <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/autoware_internal_msgs/package.xml
+++ b/autoware_internal_msgs/package.xml
@@ -18,8 +18,8 @@
   <depend>autoware_internal_metric_msgs</depend>
   <depend>autoware_internal_perception_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
-  <depend>rosidl_default_runtime</depend>
   <depend>builtin_interfaces</depend>
+  <depend>rosidl_default_runtime</depend>
   <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/autoware_internal_msgs/package.xml
+++ b/autoware_internal_msgs/package.xml
@@ -14,11 +14,11 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <exec_depend>autoware_internal_debug_msgs</exec_depend>
-  <exec_depend>autoware_internal_metric_msgs</exec_depend>
-  <exec_depend>autoware_internal_perception_msgs</exec_depend>
-  <exec_depend>autoware_internal_planning_msgs</exec_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
+  <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_metric_msgs</depend>
+  <depend>autoware_internal_perception_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
+  <depend>rosidl_default_runtime</depend>
   <depend>builtin_interfaces</depend>
   <depend>std_msgs</depend>
 

--- a/autoware_internal_msgs/package.xml
+++ b/autoware_internal_msgs/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_internal_metric_msgs</depend>
   <depend>autoware_internal_perception_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>


### PR DESCRIPTION
## Description

autoware_internal_msgs is a metapackage containing other message packages, but the dependency type has been specified as `<exec_depend>`. Semantically, 'building meta-package' should include 'building each contained package' so that dependency type should contain (at least) `<build_depend>`. This PR corrects it to `<depend>`.

This actually affects on developing 3rd-party tool to inspect correct build dependencies (e.g. I am working on [this project](https://github.com/orgs/autowarefoundation/discussions/6870)), so it should be fixed.

## How was this PR tested?

`colcon build --packages-up-to autoware_internal_msgs` builds as expected.

## Notes for reviewers

None.

## Effects on system behavior

None expected for the current workflow (colcon build everything)
