### PR TITLE
feat(planning): add trajectory validation status msgs

### DIFF
--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -14,7 +14,8 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-rosidl_generate_interfaces(${PROJECT_NAME}
+rosidl_generate_interfaces(
+  ${PROJECT_NAME}
   "msg/CandidateTrajectories.msg"
   "msg/CandidateTrajectory.msg"
   "msg/GeneratorInfo.msg"
@@ -32,20 +33,24 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VelocityLimit.msg"
   "msg/VelocityLimitConstraints.msg"
   "msg/VelocityLimitClearCommand.msg"
+  "msg/TrajectoryStatusArray.msg"
+  "msg/TrajectoryStatus.msg"
+  "msg/TrajectoryCategoryStatus.msg"
+  "msg/TrajectoryValidationStatus.msg"
+  "msg/TrajectoryMetricStatus.msg"
   "srv/ClearRoute.srv"
   "srv/LoadPlugin.srv"
   "srv/SetLaneletRoute.srv"
   "srv/SetWaypointRoute.srv"
   "srv/UnloadPlugin.srv"
   DEPENDENCIES
-    builtin_interfaces
-    geometry_msgs
-    std_msgs
-    unique_identifier_msgs
-    autoware_common_msgs
-    autoware_perception_msgs
-    autoware_planning_msgs
-)
+  builtin_interfaces
+  geometry_msgs
+  std_msgs
+  unique_identifier_msgs
+  autoware_common_msgs
+  autoware_perception_msgs
+  autoware_planning_msgs)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/autoware_internal_planning_msgs/msg/TrajectoryCategoryStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryCategoryStatus.msg
@@ -4,8 +4,7 @@
 byte OK=0
 byte WARN=1
 byte ERROR=2
-byte STALE=3
-byte UNKNOWN=4
+byte UNKNOWN=3
 
 # Name of category.
 string name

--- a/autoware_internal_planning_msgs/msg/TrajectoryCategoryStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryCategoryStatus.msg
@@ -1,0 +1,17 @@
+# This message holds a status of an individual trajectory at a specific validation category.
+
+# Possible levels of operations.
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
+byte UNKNOWN=4
+
+# Name of category.
+string name
+
+# Level of operation enumerated above.
+byte level
+
+# An array of validation/filter statuses.
+autoware_internal_planning_msgs/TrajectoryValidationStatus[] validations

--- a/autoware_internal_planning_msgs/msg/TrajectoryMetricStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryMetricStatus.msg
@@ -1,0 +1,17 @@
+# This message holds a status of an individual trajectory at a specific validation metric.
+
+# Possible levels of operations.
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
+byte UNKNOWN=4
+
+# Name of metric.
+string name
+
+# Level of operation enumerated above.
+byte level
+
+# Score can be any float value.
+float32 score

--- a/autoware_internal_planning_msgs/msg/TrajectoryMetricStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryMetricStatus.msg
@@ -13,4 +13,4 @@ string name
 byte level
 
 # Score can be any float value.
-float32 score
+float64 score

--- a/autoware_internal_planning_msgs/msg/TrajectoryMetricStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryMetricStatus.msg
@@ -4,8 +4,7 @@
 byte OK=0
 byte WARN=1
 byte ERROR=2
-byte STALE=3
-byte UNKNOWN=4
+byte UNKNOWN=3
 
 # Name of metric.
 string name

--- a/autoware_internal_planning_msgs/msg/TrajectoryStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryStatus.msg
@@ -4,8 +4,7 @@
 byte OK=0
 byte WARN=1
 byte ERROR=2
-byte STALE=3
-byte UNKNOWN=4
+byte UNKNOWN=3
 
 # Unique identifier of trajectory.
 string trajectory_id

--- a/autoware_internal_planning_msgs/msg/TrajectoryStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryStatus.msg
@@ -6,9 +6,6 @@ byte WARN=1
 byte ERROR=2
 byte UNKNOWN=3
 
-# Unique identifier of trajectory.
-string trajectory_id
-
 # Unique identifier of generator.
 unique_identifier_msgs/UUID generator_id
 

--- a/autoware_internal_planning_msgs/msg/TrajectoryStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryStatus.msg
@@ -1,0 +1,23 @@
+# This message holds a status of an individual trajectory status.
+
+# Possible levels of operations.
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
+byte UNKNOWN=4
+
+# Unique identifier of trajectory.
+string trajectory_id
+
+# Unique identifier of generator.
+unique_identifier_msgs/UUID generator_id
+
+# Timestamp at this trajectory generated.
+builtin_interfaces/Time stamp
+
+# Level of operation enumerated above.
+byte level
+
+# An array of category statuses.
+autoware_internal_planning_msgs/TrajectoryCategoryStatus[] categories

--- a/autoware_internal_planning_msgs/msg/TrajectoryStatusArray.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryStatusArray.msg
@@ -1,0 +1,4 @@
+# This message holds an array of multiple trajectories' statuses.
+
+std_msgs/Header header
+autoware_internal_planning_msgs/TrajectoryStatus[] trajectories

--- a/autoware_internal_planning_msgs/msg/TrajectoryValidationStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryValidationStatus.msg
@@ -4,8 +4,7 @@
 byte OK=0
 byte WARN=1
 byte ERROR=2
-byte STALE=3
-byte UNKNOWN=4
+byte UNKNOWN=3
 
 # Name of the validation/filter.
 string name

--- a/autoware_internal_planning_msgs/msg/TrajectoryValidationStatus.msg
+++ b/autoware_internal_planning_msgs/msg/TrajectoryValidationStatus.msg
@@ -1,0 +1,17 @@
+# This message holds a status of an individual trajectory at a specific validation/filter.
+
+# Possible levels of operations.
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
+byte UNKNOWN=4
+
+# Name of the validation/filter.
+string name
+
+# Level of the operation.
+byte level
+
+# An array of metric statuses.
+autoware_internal_planning_msgs/TrajectoryMetricStatus[] metrics


### PR DESCRIPTION
## Description

[Design document (TIER IV INTERNAL LINK)](https://tier4.atlassian.net/wiki/spaces/CB/pages/4989780748/WIP+TrajectoryValidator+Diagnostics+Handling+Design?focusedCommentId=5023596713)

This pull request is related to https://github.com/tier4/autoware_universe/pull/2768.

This pull request introduces several new message types to the `autoware_internal_planning_msgs` package, enhancing its ability to represent detailed trajectory status information. The changes primarily focus on adding new `.msg` files for tracking trajectory validation, stages, metrics, and overall status, and updating the package configuration to include these interfaces.

New trajectory status message types:

* Added `TrajectoryStatusArray.msg`, `TrajectoryStatus.msg`, `TrajectoryStageStatus.msg`, `TrajectoryValidationStatus.msg`, and `TrajectoryMetricStatus.msg` files to define structured messages for representing the status of multiple trajectories, individual trajectories, stages, validation filters, and metrics. [[1]](diffhunk://#diff-d90499ef2cf8f9711b6d01b244c33da9b7167a284a863f8277e2438350af5b40R1-R4) [[2]](diffhunk://#diff-a08796f1e8def655b48cbde6222c3ddd17ae28a605aa690ba701f7abebd64aecR1-R20) [[3]](diffhunk://#diff-2eef8bdd2c826e0d203a79963acd0f6742d78fa20d6862a8dc821ef376848615R1-R17) [[4]](diffhunk://#diff-9ec65f79dcffa55849f7144c4fb74d932c1786861906bbc1e8f979dbf8f8e8bfR1-R17) [[5]](diffhunk://#diff-978efb0cb9e8f1446f1cde1ab871743f439ad295c3a0aadc91cf623d2848efc5R1-R17)

Build configuration updates:

* Updated `CMakeLists.txt` to register the new message files with `rosidl_generate_interfaces`, ensuring they are properly built and available in the package.
* Fixed formatting and dependency listing in `CMakeLists.txt` for improved readability and correctness. [[1]](diffhunk://#diff-ad8542df5155bf52c7d5af1c0ecfd2012aa42534416b6c28c42b07e698c2ceb3L17-R18) [[2]](diffhunk://#diff-ad8542df5155bf52c7d5af1c0ecfd2012aa42534416b6c28c42b07e698c2ceb3L47-R53)

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
