### PR TITLE
refactor(autoware_internal_msgs): add USE_SCOPED_HEADER_INSTALL_DIR

### DIFF
--- a/autoware_internal_debug_msgs/CMakeLists.txt
+++ b/autoware_internal_debug_msgs/CMakeLists.txt
@@ -36,4 +36,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_internal_localization_msgs/CMakeLists.txt
+++ b/autoware_internal_localization_msgs/CMakeLists.txt
@@ -18,4 +18,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_internal_metric_msgs/CMakeLists.txt
+++ b/autoware_internal_metric_msgs/CMakeLists.txt
@@ -20,4 +20,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_internal_msgs/CMakeLists.txt
+++ b/autoware_internal_msgs/CMakeLists.txt
@@ -21,4 +21,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_internal_perception_msgs/CMakeLists.txt
+++ b/autoware_internal_perception_msgs/CMakeLists.txt
@@ -21,4 +21,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -52,4 +52,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `ament_auto_package()` calls in `autoware_internal_msgs`.

Updated packages:
- `autoware_internal_debug_msgs`
- `autoware_internal_localization_msgs`
- `autoware_internal_metric_msgs`
- `autoware_internal_msgs`
- `autoware_internal_perception_msgs`
- `autoware_internal_planning_msgs`

## How was this PR tested?

Built the target packages locally:
```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_internal_debug_msgs \
  autoware_internal_localization_msgs \
  autoware_internal_metric_msgs \
  autoware_internal_msgs \
  autoware_internal_perception_msgs \
  autoware_internal_planning_msgs
```

All packages built successfully.

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Interface changes

None.

## Effects on system behavior

No functional behavior change. This updates the package macro options for the scoped header installation migration.