### PR TITLE
feat(autoware_internal_planning_msgs): add turn_indicator field to CandidateTrajectory

### DIFF
--- a/autoware_internal_planning_msgs/CMakeLists.txt
+++ b/autoware_internal_planning_msgs/CMakeLists.txt
@@ -45,6 +45,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     autoware_common_msgs
     autoware_perception_msgs
     autoware_planning_msgs
+    autoware_vehicle_msgs
 )
 
 if(BUILD_TESTING)

--- a/autoware_internal_planning_msgs/msg/CandidateTrajectory.msg
+++ b/autoware_internal_planning_msgs/msg/CandidateTrajectory.msg
@@ -1,4 +1,4 @@
 std_msgs/Header header
 unique_identifier_msgs/UUID generator_id
 autoware_planning_msgs/TrajectoryPoint[] points
-autoware_vehicle_msgs/TurnIndicatorsCommand turn_indicator
+autoware_vehicle_msgs/TurnIndicatorsCommand turn_indicators_command

--- a/autoware_internal_planning_msgs/msg/CandidateTrajectory.msg
+++ b/autoware_internal_planning_msgs/msg/CandidateTrajectory.msg
@@ -1,3 +1,4 @@
 std_msgs/Header header
 unique_identifier_msgs/UUID generator_id
 autoware_planning_msgs/TrajectoryPoint[] points
+autoware_vehicle_msgs/TurnIndicatorsCommand turn_indicator

--- a/autoware_internal_planning_msgs/package.xml
+++ b/autoware_internal_planning_msgs/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_common_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
## Description
`CandidateTrajectory`, the message used in the Diffusion Planner architecture, cannot carry turn indicator information, so it currently has to be published on a separate topic. In this architecture, however, multiple generators produce candidates and the selector decides which generator's trajectory is actually used. To publish the turn indicator associated with the trajectory chosen by the selector, this change adds a `turn_indicator` field to `CandidateTrajectory`.

[internal link for background](https://tier4.atlassian.net/wiki/spaces/CB/pages/5264244746/Diffusion+Planner)

## How was this PR tested?
- Verified with the pilot-auto.x2 psim that, using the updated message, the selector pipeline publishes the turn indicator topic correctly.

## Notes for reviewers
- The corresponding universe changes for the Diffusion Planner will be created once the approach in this PR is agreed upon.

## Effects on system behavior
The field is additive, so existing behavior is unchanged until consumers start using it.
