### PR TITLE
feat(autoware_internal_perception_msgs): deprecate SegmentationMask.msg

### DIFF
--- a/autoware_internal_perception_msgs/msg/SegmentationMask.msg
+++ b/autoware_internal_perception_msgs/msg/SegmentationMask.msg
@@ -1,3 +1,9 @@
+# DEPRECATED as of 1.16.0. Do not use this message in new code.
+# It was added in 1.2.0 for the RTMDet instance segmentation effort
+# (autowarefoundation/autoware_universe#7235), which has been abandoned.
+# No Autoware node publishes or subscribes to it. It is kept so that any
+# out-of-tree consumer keeps building, and may be removed in a future major release.
+
 std_msgs/Header header
 
 # It represent map between instance segmentation mask and labels


### PR DESCRIPTION
## Description

- `SegmentationMask.msg` was added in 1.2.0 (#29) for the RTMDet instance segmentation effort in `autoware_universe`. That effort has been abandoned: autowarefoundation/autoware_universe#8165 was never merged, the parent issue autowarefoundation/autoware_universe#7235 is closed as not planned, and the one consumer candidate autowarefoundation/autoware_universe#9482 is also closed. Removal of the remaining artifacts is tracked in autowarefoundation/autoware#7252.

Nothing in `autoware_universe` or `autoware_core` publishes or subscribes to this message today. Neither repository references `autoware_internal_perception_msgs` at all.

**Deprecated, not removed.** `SegmentationMask.msg` is the only entry in this package's `msg_files`, so deleting it would leave `rosidl_generate_interfaces` with an empty list and effectively mean retiring the whole package. That is a much larger blast radius for no benefit. Any out-of-tree consumer keeps building. If it is still consumer-free at the next major, the package can be retired in one deliberate move.

**Why a comment banner.** rosidl has no message-level deprecation annotation: `.msg` has no annotation syntax, and `package.xml` / REP-149 define no deprecation field. A leading comment naming the release is the only mechanism, and it is what upstream does, for example `ros-controls/control_msgs` `JointControllerState.msg` ("It is deprecated as of Humble in favor of ...") and `ros2/common_interfaces` `std_msgs/Bool.msg` ("It is deprecated as of Foxy").

The banner names 1.16.0, so this should go out as a **minor** bump. Semver permits deprecating existing functionality in a minor release.

## How was this PR tested?

- Purely additive: 6 insertions, 0 deletions. Everything from `std_msgs/Header header` down is byte-identical.
- `pre-commit run --files`: end-of-file, mixed-line-ending, trailing-whitespace and prettier all pass. LF endings, single trailing newline, no trailing whitespace.
- `CMakeLists.txt` and `CHANGELOG.rst` deliberately untouched.
- The "added in 1.2.0" claim verified: commit `b037d21` (#29), earliest containing tag `1.2.0`, and the CHANGELOG lists it under `1.2.0 (2024-12-19)`.

## Interface changes

None. The message definition is unchanged, so there is no ABI or API impact.
